### PR TITLE
Composer: Aliase dev-master to 0.4.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,11 @@
     "config": {
         "sort-packages": true
     },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.4.x-dev"
+        }
+    },
     "autoload": {
         "psr-4": {
             "Itineris\\Preflight\\": "src/"


### PR DESCRIPTION
https://getcomposer.org/doc/articles/aliases.md

https://stackoverflow.com/questions/21052831/how-to-solve-two-packages-requirements-conflicts-when-running-composer-install